### PR TITLE
Adding support for Schema Registry Java SDK beta.9

### DIFF
--- a/java/avro/pom.xml
+++ b/java/avro/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>azure-schemaregistry-kafka-avro</artifactId>
-  <version>1.0.0-beta.6</version>
+  <version>1.0.0-beta.7</version>
   <name>azure-schemaregistry-kafka-avro</name>
 
 
@@ -46,17 +46,12 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-data-schemaregistry-apacheavro</artifactId>
-      <version>1.0.0-beta.8</version>
+      <version>1.0.0-beta.9</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-data-schemaregistry</artifactId>
-      <version>1.0.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.azure</groupId>
-      <artifactId>azure-core-serializer-avro-apache</artifactId>
-      <version>1.0.0-beta.17</version>
+      <version>1.0.2</version>
     </dependency>
 
     <!-- test dependencies -->

--- a/java/avro/samples/kafka-consumer/pom.xml
+++ b/java/avro/samples/kafka-consumer/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>azure-schemaregistry-kafka-avro</artifactId>
-      <version>1.0.0-beta.6</version>
+      <version>1.0.0-beta.7</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/java/avro/samples/kafka-consumer/src/main/java/com/azure/schemaregistry/samples/Order.java
+++ b/java/avro/samples/kafka-consumer/src/main/java/com/azure/schemaregistry/samples/Order.java
@@ -15,10 +15,12 @@ import org.apache.avro.message.SchemaStore;
 @org.apache.avro.specific.AvroGenerated
 public class Order extends org.apache.avro.specific.SpecificRecordBase implements org.apache.avro.specific.SpecificRecord {
   private static final long serialVersionUID = 3655407841714098520L;
+
+
   public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Order\",\"namespace\":\"com.azure.schemaregistry.samples\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"amount\",\"type\":\"double\"},{\"name\":\"description\",\"type\":\"string\"}]}");
   public static org.apache.avro.Schema getClassSchema() { return SCHEMA$; }
 
-  private static SpecificData MODEL$ = new SpecificData();
+  private static final SpecificData MODEL$ = new SpecificData();
 
   private static final BinaryMessageEncoder<Order> ENCODER =
       new BinaryMessageEncoder<Order>(MODEL$, SCHEMA$);
@@ -71,9 +73,9 @@ public class Order extends org.apache.avro.specific.SpecificRecordBase implement
     return DECODER.decode(b);
   }
 
-   private java.lang.CharSequence id;
-   private double amount;
-   private java.lang.CharSequence description;
+  private java.lang.CharSequence id;
+  private double amount;
+  private java.lang.CharSequence description;
 
   /**
    * Default constructor.  Note that this does not initialize fields
@@ -215,7 +217,7 @@ public class Order extends org.apache.avro.specific.SpecificRecordBase implement
 
     /** Creates a new Builder */
     private Builder() {
-      super(SCHEMA$);
+      super(SCHEMA$, MODEL$);
     }
 
     /**
@@ -243,7 +245,7 @@ public class Order extends org.apache.avro.specific.SpecificRecordBase implement
      * @param other The existing instance to copy.
      */
     private Builder(com.azure.schemaregistry.samples.Order other) {
-      super(SCHEMA$);
+      super(SCHEMA$, MODEL$);
       if (isValidValue(fields()[0], other.id)) {
         this.id = data().deepCopy(fields()[0].schema(), other.id);
         fieldSetFlags()[0] = true;

--- a/java/avro/samples/kafka-producer/pom.xml
+++ b/java/avro/samples/kafka-producer/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>azure-schemaregistry-kafka-avro</artifactId>
-      <version>1.0.0-beta.6</version>
+      <version>1.0.0-beta.7</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/java/avro/samples/kafka-producer/src/main/java/com/azure/schemaregistry/samples/Order.java
+++ b/java/avro/samples/kafka-producer/src/main/java/com/azure/schemaregistry/samples/Order.java
@@ -15,10 +15,12 @@ import org.apache.avro.message.SchemaStore;
 @org.apache.avro.specific.AvroGenerated
 public class Order extends org.apache.avro.specific.SpecificRecordBase implements org.apache.avro.specific.SpecificRecord {
   private static final long serialVersionUID = 3655407841714098520L;
+
+
   public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Order\",\"namespace\":\"com.azure.schemaregistry.samples\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"amount\",\"type\":\"double\"},{\"name\":\"description\",\"type\":\"string\"}]}");
   public static org.apache.avro.Schema getClassSchema() { return SCHEMA$; }
 
-  private static SpecificData MODEL$ = new SpecificData();
+  private static final SpecificData MODEL$ = new SpecificData();
 
   private static final BinaryMessageEncoder<Order> ENCODER =
       new BinaryMessageEncoder<Order>(MODEL$, SCHEMA$);
@@ -71,9 +73,9 @@ public class Order extends org.apache.avro.specific.SpecificRecordBase implement
     return DECODER.decode(b);
   }
 
-   private java.lang.CharSequence id;
-   private double amount;
-   private java.lang.CharSequence description;
+  private java.lang.CharSequence id;
+  private double amount;
+  private java.lang.CharSequence description;
 
   /**
    * Default constructor.  Note that this does not initialize fields
@@ -215,7 +217,7 @@ public class Order extends org.apache.avro.specific.SpecificRecordBase implement
 
     /** Creates a new Builder */
     private Builder() {
-      super(SCHEMA$);
+      super(SCHEMA$, MODEL$);
     }
 
     /**
@@ -243,7 +245,7 @@ public class Order extends org.apache.avro.specific.SpecificRecordBase implement
      * @param other The existing instance to copy.
      */
     private Builder(com.azure.schemaregistry.samples.Order other) {
-      super(SCHEMA$);
+      super(SCHEMA$, MODEL$);
       if (isValidValue(fields()[0], other.id)) {
         this.id = data().deepCopy(fields()[0].schema(), other.id);
         fieldSetFlags()[0] = true;
@@ -458,6 +460,7 @@ public class Order extends org.apache.avro.specific.SpecificRecordBase implement
     }
   }
 }
+
 
 
 

--- a/java/avro/samples/kafka-producer/src/main/java/com/azure/schemaregistry/samples/producer/KafkaAvroGenericRecord.java
+++ b/java/avro/samples/kafka-producer/src/main/java/com/azure/schemaregistry/samples/producer/KafkaAvroGenericRecord.java
@@ -9,12 +9,8 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.header.Header;
-import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.serialization.StringSerializer;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Properties;
 
 public class KafkaAvroGenericRecord {
@@ -55,12 +51,8 @@ public class KafkaAvroGenericRecord {
                 avroRecord.put("id", "ID-" + i);
                 avroRecord.put("amount", 20.99 + i);
                 avroRecord.put("description", "Sample order -" + i);
-                // Implementation of getting schema id from service is under development
-                // To deserialize, schema id must be manually added in a Kafka message header as a workaround
-                String schemaId = "{Place Schema Id Here}";
-                List<Header> headers = Arrays.asList(new RecordHeader("SchemaIdBytes", schemaId.getBytes()));
 
-                ProducerRecord<String, GenericRecord> record = new ProducerRecord<String, GenericRecord>(topicName, null, key, avroRecord, headers);
+                ProducerRecord<String, GenericRecord> record = new ProducerRecord<String, GenericRecord>(topicName, key, avroRecord);
                 producer.send(record);
 
                 logger.info("Sent GenericRecord: {}", record);
@@ -73,6 +65,4 @@ public class KafkaAvroGenericRecord {
             }
         }
     }
-
-
 }

--- a/java/avro/samples/kafka-producer/src/main/java/com/azure/schemaregistry/samples/producer/KafkaAvroGenericRecord.java
+++ b/java/avro/samples/kafka-producer/src/main/java/com/azure/schemaregistry/samples/producer/KafkaAvroGenericRecord.java
@@ -2,19 +2,19 @@ package com.azure.schemaregistry.samples.producer;
 
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.util.logging.ClientLogger;
-import com.microsoft.azure.schemaregistry.kafka.avro.KafkaAvroDeserializerConfig;
 import com.microsoft.azure.schemaregistry.kafka.avro.KafkaAvroSerializerConfig;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.kafka.clients.consumer.*;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.serialization.StringSerializer;
 
-import java.time.Duration;
-import java.util.Collections;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 
 public class KafkaAvroGenericRecord {
@@ -55,8 +55,12 @@ public class KafkaAvroGenericRecord {
                 avroRecord.put("id", "ID-" + i);
                 avroRecord.put("amount", 20.99 + i);
                 avroRecord.put("description", "Sample order -" + i);
+                // Implementation of getting schema id from service is under development
+                // To deserialize, schema id must be manually added in a Kafka message header as a workaround
+                String schemaId = "{Place Schema Id Here}";
+                List<Header> headers = Arrays.asList(new RecordHeader("SchemaIdBytes", schemaId.getBytes()));
 
-                ProducerRecord<String, GenericRecord> record = new ProducerRecord<String, GenericRecord>(topicName, key, avroRecord);
+                ProducerRecord<String, GenericRecord> record = new ProducerRecord<String, GenericRecord>(topicName, null, key, avroRecord, headers);
                 producer.send(record);
 
                 logger.info("Sent GenericRecord: {}", record);

--- a/java/avro/samples/kafka-producer/src/main/java/com/azure/schemaregistry/samples/producer/KafkaAvroSpecificRecord.java
+++ b/java/avro/samples/kafka-producer/src/main/java/com/azure/schemaregistry/samples/producer/KafkaAvroSpecificRecord.java
@@ -2,18 +2,18 @@ package com.azure.schemaregistry.samples.producer;
 
 import com.azure.core.credential.TokenCredential;
 import com.azure.schemaregistry.samples.Order;
-import com.microsoft.azure.schemaregistry.kafka.avro.KafkaAvroDeserializerConfig;
 import com.microsoft.azure.schemaregistry.kafka.avro.KafkaAvroSerializerConfig;
-import org.apache.kafka.clients.consumer.*;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.serialization.StringSerializer;
 import com.azure.core.util.logging.ClientLogger;
+import org.apache.kafka.common.header.Header;
 
-import java.time.Duration;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.Properties;
+import java.util.List;
 
 public class KafkaAvroSpecificRecord {
     private static final ClientLogger logger = new ClientLogger(KafkaAvroSpecificRecord.class);
@@ -44,7 +44,11 @@ public class KafkaAvroSpecificRecord {
         while (true) {
             for (int i = 0; i < 10; i++) {
                 Order order = new Order("ID-" + i, 10.99 + i, "Sample order -" + i);
-                ProducerRecord<String, Order> record = new ProducerRecord<String, Order>(topicName, key, order);
+                // Implementation of getting schema id from service is under development
+                // To deserialize, schema id must be manually added in a Kafka message header as a workaround
+                String schemaId = "{Place Schema Id Here}";
+                List<Header> headers = Arrays.asList(new RecordHeader("SchemaIdBytes", schemaId.getBytes()));
+                ProducerRecord<String, Order> record = new ProducerRecord<String, Order>(topicName, null, key, order, headers);
                 producer.send(record);
                 logger.info("Sent Order {}", order);
             }

--- a/java/avro/samples/kafka-producer/src/main/java/com/azure/schemaregistry/samples/producer/KafkaAvroSpecificRecord.java
+++ b/java/avro/samples/kafka-producer/src/main/java/com/azure/schemaregistry/samples/producer/KafkaAvroSpecificRecord.java
@@ -6,14 +6,10 @@ import com.microsoft.azure.schemaregistry.kafka.avro.KafkaAvroSerializerConfig;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.serialization.StringSerializer;
 import com.azure.core.util.logging.ClientLogger;
-import org.apache.kafka.common.header.Header;
 
-import java.util.Arrays;
 import java.util.Properties;
-import java.util.List;
 
 public class KafkaAvroSpecificRecord {
     private static final ClientLogger logger = new ClientLogger(KafkaAvroSpecificRecord.class);
@@ -44,11 +40,7 @@ public class KafkaAvroSpecificRecord {
         while (true) {
             for (int i = 0; i < 10; i++) {
                 Order order = new Order("ID-" + i, 10.99 + i, "Sample order -" + i);
-                // Implementation of getting schema id from service is under development
-                // To deserialize, schema id must be manually added in a Kafka message header as a workaround
-                String schemaId = "{Place Schema Id Here}";
-                List<Header> headers = Arrays.asList(new RecordHeader("SchemaIdBytes", schemaId.getBytes()));
-                ProducerRecord<String, Order> record = new ProducerRecord<String, Order>(topicName, null, key, order, headers);
+                ProducerRecord<String, Order> record = new ProducerRecord<String, Order>(topicName, key, order);
                 producer.send(record);
                 logger.info("Sent Order {}", order);
             }
@@ -61,4 +53,3 @@ public class KafkaAvroSpecificRecord {
         }
     }
 }
-

--- a/java/avro/src/main/java/com/microsoft/azure/schemaregistry/kafka/avro/KafkaAvroDeserializer.java
+++ b/java/avro/src/main/java/com/microsoft/azure/schemaregistry/kafka/avro/KafkaAvroDeserializer.java
@@ -3,13 +3,16 @@
 
 package com.microsoft.azure.schemaregistry.kafka.avro;
 
+import com.azure.core.experimental.models.MessageWithMetadata;
+import com.azure.core.util.BinaryData;
 import com.azure.core.util.serializer.TypeReference;
 import com.azure.data.schemaregistry.SchemaRegistryClientBuilder;
-import com.azure.data.schemaregistry.apacheavro.SchemaRegistryApacheAvroSerializer;
-import com.azure.data.schemaregistry.apacheavro.SchemaRegistryApacheAvroSerializerBuilder;
+import com.azure.data.schemaregistry.apacheavro.SchemaRegistryApacheAvroEncoder;
+import com.azure.data.schemaregistry.apacheavro.SchemaRegistryApacheAvroEncoderBuilder;
 import org.apache.kafka.common.serialization.Deserializer;
 
-import java.io.ByteArrayInputStream;
+import org.apache.kafka.common.header.Headers;
+
 import java.util.Map;
 
 /**
@@ -23,7 +26,7 @@ import java.util.Map;
  * @see KafkaAvroSerializer See serializer class for upstream serializer implementation
  */
 public class KafkaAvroDeserializer implements Deserializer<Object> {
-    private SchemaRegistryApacheAvroSerializer serializer;
+    private SchemaRegistryApacheAvroEncoder encoder;
     private KafkaAvroDeserializerConfig config;
 
     /**
@@ -50,21 +53,38 @@ public class KafkaAvroDeserializer implements Deserializer<Object> {
      * Deserializes byte array into Java object
      * @param topic topic associated with the record bytes
      * @param bytes serialized bytes, may be null
+     * @param headers record headers, may be null
      * @return deserialize object, may be null
      */
     @Override
-    public Object deserialize(String topic, byte[] bytes) {
-        ByteArrayInputStream in = new ByteArrayInputStream(bytes);
-
-        this.serializer = new SchemaRegistryApacheAvroSerializerBuilder()
+    public Object deserialize(String topic, Headers headers, byte[] bytes) {
+        this.encoder = new SchemaRegistryApacheAvroEncoderBuilder()
                 .schemaRegistryAsyncClient(new SchemaRegistryClientBuilder()
                         .fullyQualifiedNamespace(this.config.getSchemaRegistryUrl())
                         .credential(this.config.getCredential())
                         .buildAsyncClient())
                 .avroSpecificReader(this.config.getAvroSpecificReader())
-                .buildSerializer();
+                .buildEncoder();
 
-        return serializer.deserialize(in, TypeReference.createInstance(Object.class));
+        byte[] schemaIdBytes = headers.lastHeader("SchemaIdBytes").value();
+        String schemaIdString = new String(schemaIdBytes);
+        String contentType = "avro/binary+" + schemaIdString;
+
+        MessageWithMetadata message = new MessageWithMetadata();
+        message.setContentType(contentType);
+        message.setBodyAsBinaryData(BinaryData.fromBytes(bytes));
+
+        return encoder.decodeMessageData(message, TypeReference.createInstance(Object.class));
+    }
+
+    /**
+     * Deserializes byte array into Java object
+     * @param topic topic associated with the record bytes
+     * @param bytes serialized bytes, may be null
+     * @return deserialize object, may be null
+     */
+    public Object deserialize(String topic, byte[] bytes) {
+        return null;
     }
 
     @Override

--- a/java/avro/src/main/java/com/microsoft/azure/schemaregistry/kafka/avro/KafkaAvroDeserializer.java
+++ b/java/avro/src/main/java/com/microsoft/azure/schemaregistry/kafka/avro/KafkaAvroDeserializer.java
@@ -53,11 +53,10 @@ public class KafkaAvroDeserializer implements Deserializer<Object> {
      * Deserializes byte array into Java object
      * @param topic topic associated with the record bytes
      * @param bytes serialized bytes, may be null
-     * @param headers record headers, may be null
      * @return deserialize object, may be null
      */
     @Override
-    public Object deserialize(String topic, Headers headers, byte[] bytes) {
+    public Object deserialize(String topic, byte[] bytes) {
         this.encoder = new SchemaRegistryApacheAvroEncoderBuilder()
                 .schemaRegistryAsyncClient(new SchemaRegistryClientBuilder()
                         .fullyQualifiedNamespace(this.config.getSchemaRegistryUrl())
@@ -66,12 +65,7 @@ public class KafkaAvroDeserializer implements Deserializer<Object> {
                 .avroSpecificReader(this.config.getAvroSpecificReader())
                 .buildEncoder();
 
-        byte[] schemaIdBytes = headers.lastHeader("SchemaIdBytes").value();
-        String schemaIdString = new String(schemaIdBytes);
-        String contentType = "avro/binary+" + schemaIdString;
-
         MessageWithMetadata message = new MessageWithMetadata();
-        message.setContentType(contentType);
         message.setBodyAsBinaryData(BinaryData.fromBytes(bytes));
 
         return encoder.decodeMessageData(message, TypeReference.createInstance(Object.class));
@@ -81,10 +75,12 @@ public class KafkaAvroDeserializer implements Deserializer<Object> {
      * Deserializes byte array into Java object
      * @param topic topic associated with the record bytes
      * @param bytes serialized bytes, may be null
+     * @param headers record headers, may be null
      * @return deserialize object, may be null
      */
-    public Object deserialize(String topic, byte[] bytes) {
-        return null;
+    @Override
+    public Object deserialize(String topic, Headers headers, byte[] bytes) {
+        return deserialize(topic, bytes);
     }
 
     @Override


### PR DESCRIPTION
Updating dependency support for [Schema Registry Avro version beta.9](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/schemaregistry/azure-data-schemaregistry-apacheavro)

Using new "MessageWithMetadata" for serialization and deserialization; added instructions for temporary workaround while support on service backend is still in development.

Updated samples to support new version.