### PR TITLE
[Vulnerability Fix] Change Travis Test Script permissions to 755

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       before_install:
       - chmod +x ./run_java_tests.sh
       script:
-      - chmod 777 ./run_java_tests.sh
+      - chmod 755 ./run_java_tests.sh
     - language: csharp
       mono: none
       dotnet: 2.1.502


### PR DESCRIPTION
Change Travis test script to only be writable by user, solving possible vulnerability of low-privileged users to execute code as root.