### PR TITLE
Schema Registry SDK Version Update

### DIFF
--- a/java/avro/pom.xml
+++ b/java/avro/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>azure-schemaregistry-kafka-avro</artifactId>
-  <version>1.0.0-beta.9</version>
+  <version>1.0.0-beta.10</version>
   <name>azure-schemaregistry-kafka-avro</name>
 
 
@@ -46,12 +46,12 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-data-schemaregistry-apacheavro</artifactId>
-      <version>1.0.0-beta.11</version>
+      <version>1.2.0-beta.1</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-data-schemaregistry</artifactId>
-      <version>1.1.1</version>
+      <version>1.4.0-beta.1</version>
     </dependency>
 
     <!-- test dependencies -->

--- a/java/avro/pom.xml
+++ b/java/avro/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>azure-schemaregistry-kafka-avro</artifactId>
-  <version>1.0.0-beta.10</version>
+  <version>1.1.0-beta.1</version>
   <name>azure-schemaregistry-kafka-avro</name>
 
 

--- a/java/avro/samples/README.md
+++ b/java/avro/samples/README.md
@@ -22,6 +22,8 @@ The following Schema Registry configurations are required:
 - `schema.registry.url` - EH namespace with Schema Registry enabled (does not have to be the same as `bootstrap.servers`)
 - `schema.group` - Schema Registry group with serialization type 'Avro' (*must be created before the application runs*)
 - `use.managed.identity.credential` - indicates that MSI credentials should be used, should be used for MSI-enabled VM
+- `managed.identity.clientId` - if specified, will build MSI credential with given client Id
+  `managed.identity.resourceId` - if specified, will build MSI credential with given resource Id
 - `tenant.id` - sets the tenant ID of the application
 - `client.id` - sets the client ID of the application
 - `client.secret` - sets the client secret for authentication

--- a/java/avro/samples/kafka-consumer/README.md
+++ b/java/avro/samples/kafka-consumer/README.md
@@ -20,6 +20,8 @@ The following Schema Registry configurations are required:
 - `schema.registry.url` - EH namespace with Schema Registry enabled (does not have to be the same as `bootstrap.servers`)
 - `schema.group` - Schema Registry group with serialization type 'Avro' (*must be created before the application runs*)
 - `use.managed.identity.credential` - indicates that MSI credentials should be used, should be used for MSI-enabled VM
+- `managed.identity.clientId` - if specified, will build MSI credential with given client Id
+- `managed.identity.resourceId` - if specified, will build MSI credential with given resource Id
 - `tenant.id` - sets the tenant ID of the application
 - `client.id` - sets the client ID of the application
 - `client.secret` - sets the client secret for authentication

--- a/java/avro/samples/kafka-consumer/pom.xml
+++ b/java/avro/samples/kafka-consumer/pom.xml
@@ -9,7 +9,7 @@
   <groupId>com.microsoft.azure</groupId>
   <artifactId>azure-schemaregistry-avro-samples</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.0-beta.7</version>
+  <version>1.1.0-beta.1</version>
   <name>azure-schemaregistry-avro-samples</name>
   <url>http://maven.apache.org</url>
 
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>azure-schemaregistry-kafka-avro</artifactId>
-      <version>1.0.0-beta.10</version>
+      <version>1.1.0-beta.1</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/java/avro/samples/kafka-consumer/pom.xml
+++ b/java/avro/samples/kafka-consumer/pom.xml
@@ -9,7 +9,7 @@
   <groupId>com.microsoft.azure</groupId>
   <artifactId>azure-schemaregistry-avro-samples</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.0-beta.6</version>
+  <version>1.0.0-beta.7</version>
   <name>azure-schemaregistry-avro-samples</name>
   <url>http://maven.apache.org</url>
 
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>azure-schemaregistry-kafka-avro</artifactId>
-      <version>1.0.0-beta.9</version>
+      <version>1.0.0-beta.10</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
@@ -54,6 +54,11 @@
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
       <version>1.4.5</version>
+    </dependency>
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-core</artifactId>
+      <version>1.35.0</version>
     </dependency>
   </dependencies>
 

--- a/java/avro/samples/kafka-consumer/src/main/java/com/azure/schemaregistry/samples/consumer/App.java
+++ b/java/avro/samples/kafka-consumer/src/main/java/com/azure/schemaregistry/samples/consumer/App.java
@@ -23,7 +23,17 @@ public class App {
 
         TokenCredential credential;
         if (props.getProperty("use.managed.identity.credential").equals("true")) {
-            credential = new ManagedIdentityCredentialBuilder().build();
+            if (props.getProperty("managed.identity.clientId") != null) {
+                credential = new ManagedIdentityCredentialBuilder()
+                        .clientId(props.getProperty("managed.identity.clientId"))
+                        .build();
+            } else if (props.getProperty("managed.identity.resourceId") != null) {
+                credential = new ManagedIdentityCredentialBuilder()
+                        .resourceId(props.getProperty("managed.identity.resourceId"))
+                        .build();
+            } else {
+                credential = new ManagedIdentityCredentialBuilder().build();
+            }
         } else {
             credential = new ClientSecretCredentialBuilder()
                     .tenantId(props.getProperty("tenant.id"))

--- a/java/avro/samples/kafka-consumer/src/main/resources/app.properties
+++ b/java/avro/samples/kafka-consumer/src/main/resources/app.properties
@@ -11,6 +11,8 @@ schema.group=my-schema-group
 
 # used for MSI-enabled VM, ignores client secret credentials if enabled
 use.managed.identity.credential=false
+managed.identity.clientId=[msi-clientId]
+managed.identity.resourceId=[msi-resourceId]
 
 tenant.id=[tenant-id]
 client.id=[client-id]

--- a/java/avro/samples/kafka-producer/pom.xml
+++ b/java/avro/samples/kafka-producer/pom.xml
@@ -9,7 +9,7 @@
   <groupId>com.microsoft.azure</groupId>
   <artifactId>azure-schemaregistry-avro-samples</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.0-beta.7</version>
+  <version>1.1.0-beta.1</version>
   <name>azure-schemaregistry-avro-samples</name>
   <url>http://maven.apache.org</url>
 
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>azure-schemaregistry-kafka-avro</artifactId>
-      <version>1.0.0-beta.10</version>
+      <version>1.1.0-beta.1</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/java/avro/samples/kafka-producer/pom.xml
+++ b/java/avro/samples/kafka-producer/pom.xml
@@ -9,7 +9,7 @@
   <groupId>com.microsoft.azure</groupId>
   <artifactId>azure-schemaregistry-avro-samples</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.0-beta.6</version>
+  <version>1.0.0-beta.7</version>
   <name>azure-schemaregistry-avro-samples</name>
   <url>http://maven.apache.org</url>
 
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>azure-schemaregistry-kafka-avro</artifactId>
-      <version>1.0.0-beta.9</version>
+      <version>1.0.0-beta.10</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
@@ -54,6 +54,11 @@
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
       <version>1.4.5</version>
+    </dependency>
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-core</artifactId>
+      <version>1.35.0</version>
     </dependency>
   </dependencies>
 

--- a/java/avro/samples/kafka-producer/src/main/java/com/azure/schemaregistry/samples/producer/App.java
+++ b/java/avro/samples/kafka-producer/src/main/java/com/azure/schemaregistry/samples/producer/App.java
@@ -24,7 +24,17 @@ public class App {
 
         TokenCredential credential;
         if (props.getProperty("use.managed.identity.credential").equals("true")) {
-            credential = new ManagedIdentityCredentialBuilder().build();
+            if (props.getProperty("managed.identity.clientId") != null) {
+                credential = new ManagedIdentityCredentialBuilder()
+                        .clientId(props.getProperty("managed.identity.clientId"))
+                        .build();
+            } else if (props.getProperty("managed.identity.resourceId") != null) {
+                credential = new ManagedIdentityCredentialBuilder()
+                        .resourceId(props.getProperty("managed.identity.resourceId"))
+                        .build();
+            } else {
+                credential = new ManagedIdentityCredentialBuilder().build();
+            }
         } else {
             credential = new ClientSecretCredentialBuilder()
                     .tenantId(props.getProperty("tenant.id"))

--- a/java/avro/samples/kafka-producer/src/main/resources/app.properties
+++ b/java/avro/samples/kafka-producer/src/main/resources/app.properties
@@ -11,6 +11,8 @@ schema.group=my-schema-group
 
 # used for MSI-enabled VM, ignores client secret credentials if enabled
 use.managed.identity.credential=false
+managed.identity.clientId=[msi-clientid]
+managed.identity.resourceId=[msi-resourceid]
 
 tenant.id=[tenant-id]
 client.id=[client-id]

--- a/java/avro/src/main/java/com/microsoft/azure/schemaregistry/kafka/avro/KafkaAvroDeserializer.java
+++ b/java/avro/src/main/java/com/microsoft/azure/schemaregistry/kafka/avro/KafkaAvroDeserializer.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.azure.schemaregistry.kafka.avro;
 
-import com.azure.core.experimental.models.MessageWithMetadata;
+import com.azure.core.models.MessageContent;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.serializer.TypeReference;
 import com.azure.data.schemaregistry.SchemaRegistryClientBuilder;
@@ -49,7 +49,7 @@ public class KafkaAvroDeserializer<T extends IndexedRecord> implements Deseriali
         this.config = new KafkaAvroDeserializerConfig((Map<String, Object>) props);
 
         this.serializer = new SchemaRegistryApacheAvroSerializerBuilder()
-            .schemaRegistryAsyncClient(
+            .schemaRegistryClient(
                 new SchemaRegistryClientBuilder()
                     .fullyQualifiedNamespace(this.config.getSchemaRegistryUrl())
                     .credential(this.config.getCredential())
@@ -78,7 +78,7 @@ public class KafkaAvroDeserializer<T extends IndexedRecord> implements Deseriali
      */
     @Override
     public T deserialize(String topic, Headers headers, byte[] bytes) {
-        MessageWithMetadata message = new MessageWithMetadata();
+        MessageContent message = new MessageContent();
         message.setBodyAsBinaryData(BinaryData.fromBytes(bytes));
 
         Header contentTypeHeader = headers.lastHeader("content-type");
@@ -88,9 +88,9 @@ public class KafkaAvroDeserializer<T extends IndexedRecord> implements Deseriali
             message.setContentType("");
         }
 
-        return (T) this.serializer.deserializeMessageData(
-            message,
-            TypeReference.createInstance(this.config.getAvroSpecificType()));
+        return (T) this.serializer.deserialize(
+                message,
+                TypeReference.createInstance(this.config.getAvroSpecificType()));
     }
 
     @Override

--- a/java/avro/src/main/java/com/microsoft/azure/schemaregistry/kafka/avro/KafkaAvroSerializer.java
+++ b/java/avro/src/main/java/com/microsoft/azure/schemaregistry/kafka/avro/KafkaAvroSerializer.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.azure.schemaregistry.kafka.avro;
 
-import com.azure.core.experimental.models.MessageWithMetadata;
+import com.azure.core.models.MessageContent;
 import com.azure.core.util.serializer.TypeReference;
 import com.azure.data.schemaregistry.SchemaRegistryClientBuilder;
 import com.azure.data.schemaregistry.apacheavro.SchemaRegistryApacheAvroSerializer;
@@ -48,12 +48,12 @@ public class KafkaAvroSerializer<T> implements Serializer<T> {
         KafkaAvroSerializerConfig config = new KafkaAvroSerializerConfig((Map<String, Object>) props);
 
         this.serializer = new SchemaRegistryApacheAvroSerializerBuilder()
-                .schemaRegistryAsyncClient(new SchemaRegistryClientBuilder()
+                .schemaRegistryClient(new SchemaRegistryClientBuilder()
                         .fullyQualifiedNamespace(config.getSchemaRegistryUrl())
                         .credential(config.getCredential())
                         .buildAsyncClient())
                 .schemaGroup(config.getSchemaGroup())
-                .autoRegisterSchema(config.getAutoRegisterSchemas())
+                .autoRegisterSchemas(config.getAutoRegisterSchemas())
                 .buildSerializer();
     }
 
@@ -96,12 +96,10 @@ public class KafkaAvroSerializer<T> implements Serializer<T> {
         if (record == null) {
             return null;
         }
-        
-        MessageWithMetadata message =
-            this.serializer.serializeMessageData(record, TypeReference.createInstance(MessageWithMetadata.class));
-        String messageContentType = message.getContentType();
-        byte[] contentTypeBytes = messageContentType.getBytes();
-        headers.add("content-type", contentTypeBytes);
+
+        MessageContent message = this.serializer.serialize(record, TypeReference.createInstance(MessageContent.class));
+        byte[] contentTypeHeaderBytes = message.getContentType().getBytes();
+        headers.add("content-type", contentTypeHeaderBytes);
         return message.getBodyAsBinaryData().toBytes();
     }
 


### PR DESCRIPTION
This PR updates the `azure-schema-registry-for-kafka` package with the latest SDK versions from the Java SDK for Azure.
- Updates packages `azure-data-schemaregistry` and `azure-data-schemaregistry-apacheavro` packages
- Updates Serializer and Deserializer to use new methods from new SDK libraries
- Updates sample packages using new serializers