### PR TITLE
Schema Registry Json Serializer Sample

### DIFF
--- a/java/json/pom.xml
+++ b/java/json/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.microsoft.azure</groupId>
+    <artifactId>azure-schemaregistry-kafka</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <artifactId>azure-schemaregistry-kafka-json</artifactId>
+  <version>1.0.0-beta.1</version>
+  <name>azure-schemaregistry-kafka-json</name>
+
+  <scm>
+    <url>scm:git:https://github.com/Azure/azure-schema-registry-for-kafka</url>
+    <connection>scm:git:git@github.com:Azure/azure-schema-registry-for-kafka.git</connection>
+    <tag>HEAD</tag>
+  </scm>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/java/json/src/samples/comsumer/pom.xml
+++ b/java/json/src/samples/comsumer/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.microsoft.azure</groupId>
+  <artifactId>azure-schemaregistry-kafka-json-samples</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0.0-beta.1</version>
+  <name>azure-schemaregistry-kafka-json-samples</name>
+  <url>http://maven.apache.org</url>
+
+  <properties>
+      <maven.compiler.source>1.8</maven.compiler.source>
+      <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-data-schemaregistry</artifactId>
+      <version>1.4.0-beta.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>3.3.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-identity</artifactId>
+      <version>1.8.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.14.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.victools</groupId>
+      <artifactId>jsonschema-generator</artifactId>
+      <version>4.28.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.networknt</groupId>
+      <artifactId>json-schema-validator</artifactId>
+      <version>1.0.76</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/java/json/src/samples/comsumer/src/main/java/com/azure/schemaregistry/samples/Order.java
+++ b/java/json/src/samples/comsumer/src/main/java/com/azure/schemaregistry/samples/Order.java
@@ -1,0 +1,48 @@
+package com.azure.schemaregistry.samples;
+
+public class Order {
+  private String id;
+  private double amount;
+  private String description;
+
+  public Order() {}
+
+  public Order(String id, double amount, String description) {
+    this.id = id;
+    this.amount = amount;
+    this.description = description;
+  }
+
+  public String getId() {
+    return this.id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public double getAmount() {
+    return this.amount;
+  }
+
+  public void setAmount(double amount) {
+    this.amount = amount;
+  }
+
+  public String getDescription() {
+    return this.description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+      "{Order Id: %1$s, Order Amount: %2$s, Order Description: %3$s}",
+      this.id,
+      this.amount,
+      this.description);
+  }
+}

--- a/java/json/src/samples/comsumer/src/main/java/com/azure/schemaregistry/samples/consumer/App.java
+++ b/java/json/src/samples/comsumer/src/main/java/com/azure/schemaregistry/samples/consumer/App.java
@@ -1,0 +1,60 @@
+package com.azure.schemaregistry.samples.consumer;
+
+import java.io.FileInputStream;
+import java.util.Properties;
+import java.util.Scanner;
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.ClientSecretCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+public class App 
+{
+    public static void main( String[] args ) throws Exception {
+        Properties props = new Properties();
+        props.load(new FileInputStream("src/main/java/resources/app.properties"));
+
+        // EH specific properties
+        String brokerUrl = props.getProperty("bootstrap.servers");
+        String jaasConfig = props.getProperty("sasl.jaas.config");
+        String topicName = props.getProperty("topic");
+
+        // Schema Registry specific properties
+        String registryUrl = props.getProperty("schema.registry.url");
+
+        TokenCredential credential;
+        if (props.getProperty("use.managed.identity.credential").equals("true")) {
+            if (props.getProperty("managed.identity.clientId") != null) {
+                credential = new ManagedIdentityCredentialBuilder()
+                        .clientId(props.getProperty("managed.identity.clientId"))
+                        .build();
+            } else if (props.getProperty("managed.identity.resourceId") != null) {
+                credential = new ManagedIdentityCredentialBuilder()
+                        .resourceId(props.getProperty("managed.identity.resourceId"))
+                        .build();
+            } else {
+                credential = new ManagedIdentityCredentialBuilder().build();
+            }
+        } else {
+            credential = new ClientSecretCredentialBuilder()
+                    .tenantId(props.getProperty("tenant.id"))
+                    .clientId(props.getProperty("client.id"))
+                    .clientSecret(props.getProperty("client.secret"))
+                    .build();
+        }
+
+        Scanner in = new Scanner(System.in);
+
+        System.out.println("Enter case number:");
+        System.out.println("1 - consume Avro SpecificRecords");
+        int caseNum = in.nextInt();
+
+        switch (caseNum) {
+            case 1:
+                KafkaJsonSpecificRecord.consumeSpecificRecords(brokerUrl, registryUrl, jaasConfig, topicName, credential);
+                break;
+            default:
+                System.out.println("No sample matched");
+        }
+        in.close();
+    }
+}

--- a/java/json/src/samples/comsumer/src/main/java/com/azure/schemaregistry/samples/consumer/KafkaJsonDeserializer.java
+++ b/java/json/src/samples/comsumer/src/main/java/com/azure/schemaregistry/samples/consumer/KafkaJsonDeserializer.java
@@ -1,0 +1,83 @@
+package com.azure.schemaregistry.samples.consumer;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Deserializer;
+import com.azure.data.schemaregistry.SchemaRegistryClient;
+import com.azure.data.schemaregistry.SchemaRegistryClientBuilder;
+import com.azure.data.schemaregistry.models.SchemaRegistrySchema;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+
+public class KafkaJsonDeserializer<T> implements Deserializer<T> {
+  private SchemaRegistryClient client;
+  private KafkaJsonDeserializerConfig config;
+
+  public KafkaJsonDeserializer() {
+    super();
+  }
+
+  public void configure(Map<String, ?> props, boolean isKey) {
+    this.config = new KafkaJsonDeserializerConfig((Map<String, Object>) props);
+
+    this.client = new SchemaRegistryClientBuilder()
+    .fullyQualifiedNamespace(this.config.getSchemaRegistryUrl())
+    .credential(this.config.getCredential())
+    .buildClient();
+  }
+
+  @Override
+  public T deserialize(String topic, byte[] data) {
+    return null;
+  }
+
+  @Override
+  public T deserialize(String topic, Headers headers, byte[] data) {
+    T dataObject;
+    String schemaId;
+
+    ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.setVisibility(mapper.getVisibilityChecker().withFieldVisibility(JsonAutoDetect.Visibility.ANY));
+    try {
+      dataObject = (T) mapper.readValue(data, this.config.getJsonSpecificType());
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw new Error(e);
+    }
+
+    if (headers.lastHeader("schemaId") != null) {
+      schemaId = new String(headers.lastHeader("schemaId").value());
+    } else {
+      throw new RuntimeException("Schema Id was not found in record headers.");
+    }
+    SchemaRegistrySchema schema = this.client.getSchema(schemaId);
+
+    JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
+    JsonSchema jSchema = factory.getSchema(schema.getDefinition());
+    JsonNode node;
+    try {
+      node = mapper.readTree(data);
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw new Error(e);
+    }
+    Set<ValidationMessage> errors = jSchema.validate(node);
+
+    if (errors.size() == 0) {
+      return dataObject;
+    } else {
+      throw new RuntimeException("Failed to validate Json data. Validation errors:\n" + Arrays.toString(errors.toArray()));
+    }
+  }
+
+  @Override
+  public void close() {}
+}

--- a/java/json/src/samples/comsumer/src/main/java/com/azure/schemaregistry/samples/consumer/KafkaJsonDeserializerConfig.java
+++ b/java/json/src/samples/comsumer/src/main/java/com/azure/schemaregistry/samples/consumer/KafkaJsonDeserializerConfig.java
@@ -1,0 +1,24 @@
+package com.azure.schemaregistry.samples.consumer;
+
+import java.util.Map;
+import com.azure.core.credential.TokenCredential;
+
+public class KafkaJsonDeserializerConfig {
+  private Map<String, Object> props;
+
+  KafkaJsonDeserializerConfig(Map<String, Object> props) {
+    this.props = (Map<String, Object>) props;
+  }
+
+  public String getSchemaRegistryUrl() {
+    return (String) this.props.get("schema.registry.url");
+  }
+
+  public TokenCredential getCredential() {
+    return (TokenCredential) this.props.get("schema.registry.credential");
+  }
+
+  public Class<?> getJsonSpecificType() {
+    return (Class<?>) this.props.getOrDefault("specific.value.type", Object.class);
+  }
+}

--- a/java/json/src/samples/comsumer/src/main/java/com/azure/schemaregistry/samples/consumer/KafkaJsonSpecificRecord.java
+++ b/java/json/src/samples/comsumer/src/main/java/com/azure/schemaregistry/samples/consumer/KafkaJsonSpecificRecord.java
@@ -1,0 +1,56 @@
+package com.azure.schemaregistry.samples.consumer;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.util.logging.ClientLogger;
+import com.azure.schemaregistry.samples.Order;
+
+public class KafkaJsonSpecificRecord {
+  private static final ClientLogger logger = new ClientLogger(KafkaJsonSpecificRecord.class);
+
+  public static void consumeSpecificRecords(
+    String brokerUrl, String registryUrl, String jaasConfig, String topicName, TokenCredential credential) {
+    Properties props = new Properties();
+
+    // EH Kafka Configs
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerUrl);
+    props.put("security.protocol", "SASL_SSL");
+    props.put("sasl.mechanism", "PLAIN");
+    props.put("sasl.jaas.config", jaasConfig);
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, "testgroup");
+      props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+            StringDeserializer.class);
+    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+            com.azure.schemaregistry.samples.consumer.KafkaJsonDeserializer.class);
+
+    // Schema Registry configs
+    props.put("schema.registry.url", registryUrl);
+    props.put("schema.registry.credential", credential);
+    props.put("auto.register.schemas", true);
+    props.put("specific.value.type", Order.class);
+
+    final KafkaConsumer<String, Order> consumer = new KafkaConsumer<>(props);
+    consumer.subscribe(Collections.singletonList(topicName));
+
+    try {
+      System.out.println("Reading records...");
+      while (true) {
+          ConsumerRecords<String, Order> records = consumer.poll(Duration.ofMillis(5000));
+          for (ConsumerRecord<String, Order> record : records) {
+              logger.info("Order received: " + record.value().toString());
+              System.out.println("Order received: " + record.value().toString());
+          }
+      }
+    } finally {
+      consumer.close();
+    }
+  }
+}

--- a/java/json/src/samples/comsumer/src/main/java/resources/app.properties
+++ b/java/json/src/samples/comsumer/src/main/java/resources/app.properties
@@ -1,0 +1,19 @@
+# standard EH Kafka configs
+bootstrap.servers=[my-eh-namespace].servicebus.windows.net:9093
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password="Endpoint=sb://[my-eh-namespace].servicebus.windows.net/;SharedAccessKeyName=XXXXXX;SharedAccessKey=XXXXXX";
+topic=[topic-name]
+
+# schema registry specific configs
+schema.registry.url=https://[schema-registry-namespace].servicebus.windows.net
+
+# used by producer only
+schema.group=my-schema-group
+
+# used for MSI-enabled VM, ignores client secret credentials if enabled
+use.managed.identity.credential=false
+managed.identity.clientId=[msi-clientid]
+managed.identity.resourceId=[msi-resourceid]
+
+tenant.id=[tenant-id]
+client.id=[client-id]
+client.secret=[client-secret]

--- a/java/json/src/samples/comsumer/src/test/java/com/microsoft/azure/AppTest.java
+++ b/java/json/src/samples/comsumer/src/test/java/com/microsoft/azure/AppTest.java
@@ -1,0 +1,38 @@
+package com.microsoft.azure;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest 
+    extends TestCase
+{
+    /**
+     * Create the test case
+     *
+     * @param testName name of the test case
+     */
+    public AppTest( String testName )
+    {
+        super( testName );
+    }
+
+    /**
+     * @return the suite of tests being tested
+     */
+    public static Test suite()
+    {
+        return new TestSuite( AppTest.class );
+    }
+
+    /**
+     * Rigourous Test :-)
+     */
+    public void testApp()
+    {
+        assertTrue( true );
+    }
+}

--- a/java/json/src/samples/producer/pom.xml
+++ b/java/json/src/samples/producer/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.microsoft.azure</groupId>
+  <artifactId>azure-schemaregistry-kafka-json-samples</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0.0-beta.1</version>
+  <name>azure-schemaregistry-kafka-json-samples</name>
+  <url>http://maven.apache.org</url>
+
+  <properties>
+      <maven.compiler.source>1.8</maven.compiler.source>
+      <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-data-schemaregistry</artifactId>
+      <version>1.4.0-beta.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>3.3.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-identity</artifactId>
+      <version>1.8.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.14.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.victools</groupId>
+      <artifactId>jsonschema-generator</artifactId>
+      <version>4.28.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/java/json/src/samples/producer/src/main/java/com/azure/schemaregistry/samples/Order.java
+++ b/java/json/src/samples/producer/src/main/java/com/azure/schemaregistry/samples/Order.java
@@ -1,0 +1,39 @@
+package com.azure.schemaregistry.samples;
+
+public class Order {
+  private String id;
+  private double amount;
+  private String description;
+
+  public Order() {}
+
+  public Order(String id, double amount, String description) {
+    this.id = id;
+    this.amount = amount;
+    this.description = description;
+  }
+
+  public String getId() {
+    return this.id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public double getAmount() {
+    return this.amount;
+  }
+
+  public void setAmount(double amount) {
+    this.amount = amount;
+  }
+
+  public String getDescription() {
+    return this.description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+}

--- a/java/json/src/samples/producer/src/main/java/com/azure/schemaregistry/samples/producer/App.java
+++ b/java/json/src/samples/producer/src/main/java/com/azure/schemaregistry/samples/producer/App.java
@@ -1,0 +1,61 @@
+package com.azure.schemaregistry.samples.producer;
+
+import java.io.FileInputStream;
+import java.util.Properties;
+import java.util.Scanner;
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.ClientSecretCredentialBuilder;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+
+public class App 
+{
+    public static void main( String[] args ) throws Exception {
+        Properties props = new Properties();
+        props.load(new FileInputStream("src/main/java/resources/app.properties"));
+
+        // EH specific properties
+        String brokerUrl = props.getProperty("bootstrap.servers");
+        String jaasConfig = props.getProperty("sasl.jaas.config");
+        String topicName = props.getProperty("topic");
+
+        // Schema Registry specific properties
+        String registryUrl = props.getProperty("schema.registry.url");
+        String schemaGroup = props.getProperty("schema.group");
+
+        TokenCredential credential;
+        if (props.getProperty("use.managed.identity.credential").equals("true")) {
+            if (props.getProperty("managed.identity.clientId") != null) {
+                credential = new ManagedIdentityCredentialBuilder()
+                        .clientId(props.getProperty("managed.identity.clientId"))
+                        .build();
+            } else if (props.getProperty("managed.identity.resourceId") != null) {
+                credential = new ManagedIdentityCredentialBuilder()
+                        .resourceId(props.getProperty("managed.identity.resourceId"))
+                        .build();
+            } else {
+                credential = new ManagedIdentityCredentialBuilder().build();
+            }
+        } else {
+            credential = new ClientSecretCredentialBuilder()
+                    .tenantId(props.getProperty("tenant.id"))
+                    .clientId(props.getProperty("client.id"))
+                    .clientSecret(props.getProperty("client.secret"))
+                    .build();
+        }
+
+        Scanner in = new Scanner(System.in);
+
+        System.out.println("Enter case number:");
+        System.out.println("1 - produce Avro SpecificRecords");
+        int caseNum = in.nextInt();
+
+        switch (caseNum) {
+            case 1:
+                KafkaJsonSpecificRecord.produceSpecificRecords(brokerUrl, registryUrl, jaasConfig, topicName, schemaGroup, credential);
+                break;
+            default:
+                System.out.println("No sample matched");
+        }
+        in.close();
+    }
+}

--- a/java/json/src/samples/producer/src/main/java/com/azure/schemaregistry/samples/producer/KafkaJsonSerializer.java
+++ b/java/json/src/samples/producer/src/main/java/com/azure/schemaregistry/samples/producer/KafkaJsonSerializer.java
@@ -1,0 +1,80 @@
+package com.azure.schemaregistry.samples.producer;
+
+import java.util.Map;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Serializer;
+import com.azure.data.schemaregistry.SchemaRegistryClient;
+import com.azure.data.schemaregistry.SchemaRegistryClientBuilder;
+import com.azure.data.schemaregistry.models.SchemaFormat;
+import com.azure.data.schemaregistry.models.SchemaProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.victools.jsonschema.generator.OptionPreset;
+import com.github.victools.jsonschema.generator.SchemaGenerator;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.SchemaVersion;
+
+public class KafkaJsonSerializer<T> implements Serializer<T> {
+  private SchemaRegistryClient client;
+  private String schemaGroup;
+
+  public KafkaJsonSerializer() {
+    super();
+  }
+
+  @Override
+  public void configure(Map<String, ?> props, boolean isKey) {
+    KafkaJsonSerializerConfig config = new KafkaJsonSerializerConfig((Map<String, Object>) props);
+
+    this.schemaGroup = config.getSchemaGroup();
+    
+    this.client = new SchemaRegistryClientBuilder()
+    .fullyQualifiedNamespace(config.getSchemaRegistryUrl())
+    .credential(config.getCredential())
+    .buildClient();
+  }
+
+  @Override
+  public byte[] serialize(String topic, T data) {
+    return null;
+  }
+
+  @Override
+  public byte[] serialize(String topic, Headers headers, T record) {
+    if (record == null) {
+      return null;
+    }
+
+    byte[] recordBytes;
+
+    ObjectMapper mapper = new ObjectMapper();
+    try {
+      recordBytes = mapper.writeValueAsBytes(record);
+    } catch (JsonProcessingException e) {
+      e.printStackTrace();
+      throw new Error(e);
+    }
+
+    SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON);
+    SchemaGeneratorConfig config = configBuilder.build();
+    SchemaGenerator generator = new SchemaGenerator(config);
+    JsonNode jsonSchema = generator.generateSchema(record.getClass());
+    String jsonSchemaString = jsonSchema.toString();
+
+    SchemaProperties schemaProps = this.client.registerSchema(
+      this.schemaGroup,
+      record.getClass().getName(),
+      jsonSchemaString,
+      SchemaFormat.JSON
+    );
+
+    headers.add("schemaId", schemaProps.getId().getBytes());
+
+    return recordBytes;
+  }
+
+  @Override
+  public void close() {}
+}

--- a/java/json/src/samples/producer/src/main/java/com/azure/schemaregistry/samples/producer/KafkaJsonSerializerConfig.java
+++ b/java/json/src/samples/producer/src/main/java/com/azure/schemaregistry/samples/producer/KafkaJsonSerializerConfig.java
@@ -1,0 +1,24 @@
+package com.azure.schemaregistry.samples.producer;
+
+import java.util.Map;
+import com.azure.core.credential.TokenCredential;
+
+public class KafkaJsonSerializerConfig {
+  private Map<String, Object> props;
+
+  KafkaJsonSerializerConfig(Map<String, Object> props) {
+    this.props = (Map<String, Object>) props;
+  }
+
+  public String getSchemaRegistryUrl() {
+    return (String) this.props.get("schema.registry.url");
+  }
+
+  public TokenCredential getCredential() {
+    return (TokenCredential) this.props.get("schema.registry.credential");
+  }
+
+  public String getSchemaGroup() {
+    return (String) this.props.get("schema.group");
+  }
+}

--- a/java/json/src/samples/producer/src/main/java/com/azure/schemaregistry/samples/producer/KafkaJsonSpecificRecord.java
+++ b/java/json/src/samples/producer/src/main/java/com/azure/schemaregistry/samples/producer/KafkaJsonSpecificRecord.java
@@ -1,0 +1,60 @@
+package com.azure.schemaregistry.samples.producer;
+
+import java.util.Properties;
+import java.util.Random;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.util.logging.ClientLogger;
+import com.azure.schemaregistry.samples.Order;
+
+public class KafkaJsonSpecificRecord {
+  private static final ClientLogger logger = new ClientLogger(KafkaJsonSpecificRecord.class);
+
+  public static void produceSpecificRecords(
+    String brokerUrl, String registryUrl, String jaasConfig, String topicName, String schemaGroup, TokenCredential credential) {
+    Properties props = new Properties();
+
+    // EH Kafka Configs
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerUrl);
+    props.put("security.protocol", "SASL_SSL");
+    props.put("sasl.mechanism", "PLAIN");
+    props.put("sasl.jaas.config", jaasConfig);
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+            StringSerializer.class);
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+            com.azure.schemaregistry.samples.producer.KafkaJsonSerializer.class);
+
+    // Schema Registry configs
+    props.put("schema.registry.url", registryUrl);
+    props.put("schema.registry.credential", credential);
+    props.put("auto.register.schemas", true);
+    props.put("schema.group", schemaGroup);
+    KafkaProducer<String, Order> producer = new KafkaProducer<String,Order>(props);
+
+    String key = "sample-key";
+
+    System.out.println("Producing records...");
+    try {
+    while (true) {
+        for (int i = 0; i < 10; i++) {
+            Order order = new Order("ID-" + i, 0.99 + i, "Sample order #" + Math.abs(new Random().nextInt()));
+            ProducerRecord<String, Order> record = new ProducerRecord<String, Order>(topicName, key, order);
+            producer.send(record);
+            logger.info("Sent Order {}", order);
+            System.out.println("Sent Order " + order.getId());
+        }
+        producer.flush();
+        try {
+            Thread.sleep(10000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+    } finally {
+        producer.close();
+    }
+  }
+}

--- a/java/json/src/samples/producer/src/main/java/resources/app.properties
+++ b/java/json/src/samples/producer/src/main/java/resources/app.properties
@@ -1,0 +1,19 @@
+# standard EH Kafka configs
+bootstrap.servers=[my-eh-namespace].servicebus.windows.net:9093
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password="Endpoint=sb://[my-eh-namespace].servicebus.windows.net/;SharedAccessKeyName=XXXXXX;SharedAccessKey=XXXXXX";
+topic=[topic-name]
+
+# schema registry specific configs
+schema.registry.url=https://[schema-registry-namespace].servicebus.windows.net
+
+# used by producer only
+schema.group=my-schema-group
+
+# used for MSI-enabled VM, ignores client secret credentials if enabled
+use.managed.identity.credential=false
+managed.identity.clientId=[msi-clientid]
+managed.identity.resourceId=[msi-resourceid]
+
+tenant.id=[tenant-id]
+client.id=[client-id]
+client.secret=[client-secret]

--- a/java/json/src/samples/producer/src/test/java/com/microsoft/azure/AppTest.java
+++ b/java/json/src/samples/producer/src/test/java/com/microsoft/azure/AppTest.java
@@ -1,0 +1,38 @@
+package com.microsoft.azure;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest 
+    extends TestCase
+{
+    /**
+     * Create the test case
+     *
+     * @param testName name of the test case
+     */
+    public AppTest( String testName )
+    {
+        super( testName );
+    }
+
+    /**
+     * @return the suite of tests being tested
+     */
+    public static Test suite()
+    {
+        return new TestSuite( AppTest.class );
+    }
+
+    /**
+     * Rigourous Test :-)
+     */
+    public void testApp()
+    {
+        assertTrue( true );
+    }
+}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -2,10 +2,7 @@
 <!--
   ~ Copyright (c) Microsoft Corporation. All rights reserved.
   ~ Licensed under the MIT License.
-  -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-schemaregistry-kafka</artifactId>
@@ -13,6 +10,7 @@
     <version>1.0.0</version>  <!-- do not change-->
     <modules>
         <module>avro</module>
+        <module>json</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
This pull request adds a proof-of-concept serializer and deserializer compatible with Json schemas integrated with Azure Schema Registry
- Add producer and consumer samples using Json serializers implemented using the Jackson core library
- Create and register schema to schema registry on data production, read and validate data from schema on data consumption
- Add small sample apps to run the producer and consumer as separate processes