### PR TITLE
Avro and Json Fixes for Java

### DIFF
--- a/java/avro/samples/kafka-consumer/pom.xml
+++ b/java/avro/samples/kafka-consumer/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
-      <version>1.4.5</version>
+      <version>1.8.2</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/java/avro/samples/kafka-producer/pom.xml
+++ b/java/avro/samples/kafka-producer/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
-      <version>1.4.5</version>
+      <version>1.8.2</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/java/json/src/main/java/com/microsoft/azure/schemaregistry/kafka/json/KafkaJsonSerializer.java
+++ b/java/json/src/main/java/com/microsoft/azure/schemaregistry/kafka/json/KafkaJsonSerializer.java
@@ -54,7 +54,7 @@ public class KafkaJsonSerializer<T> implements Serializer<T> {
         this.client = new SchemaRegistryClientBuilder()
         .fullyQualifiedNamespace(config.getSchemaRegistryUrl())
         .credential(config.getCredential())
-        .clientOptions(new ClientOptions().setApplicationId("azsdk-java-KafkaJsonSerializer/1.0.0-beta.1"))
+        .clientOptions(new ClientOptions().setApplicationId("KafkaJsonSerializer/1.0"))
         .buildClient();
     }
 


### PR DESCRIPTION
This PR contains some small fixes for the Avro and Json implementation of the Kafka Serializer for Java

- Bumps azure-identity package in Avro samples to make use of `resourceId` in managed identity scenarios
- Shortens `ApplicationId` name in Json serializer to fit under the maximum character length