### PR TITLE
Auto-Register Schema Config Check in Json Serializers

### DIFF
--- a/csharp/avro/src/KafkaAvroDeserializer.cs
+++ b/csharp/avro/src/KafkaAvroDeserializer.cs
@@ -29,7 +29,18 @@ namespace Microsoft.Azure.Kafka.SchemaRegistry.Avro
         /// <param name="credential"></param> TokenCredential implementation for OAuth2 authentication
         public KafkaAvroDeserializer(string schemaRegistryUrl, TokenCredential credential)
         {
-            this.serializer = new SchemaRegistryAvroSerializer(new SchemaRegistryClient(schemaRegistryUrl, credential), "$default");
+            this.serializer = new SchemaRegistryAvroSerializer(
+                new SchemaRegistryClient(
+                    schemaRegistryUrl,
+                    credential, 
+                    new SchemaRegistryClientOptions
+                        {
+                            Diagnostics =
+                            {
+                                ApplicationId = "net-avro-kafka-des-1.0"
+                            }
+                        }),
+                "$default");
         }
         
         public T Deserialize(ReadOnlySpan<byte> data, bool isNull, SerializationContext context)

--- a/csharp/avro/src/KafkaAvroSerializer.cs
+++ b/csharp/avro/src/KafkaAvroSerializer.cs
@@ -29,7 +29,14 @@ namespace Microsoft.Azure.Kafka.SchemaRegistry.Avro
             this.serializer = new SchemaRegistryAvroSerializer(
                 new SchemaRegistryClient(
                     schemaRegistryUrl,
-                    credential),
+                    credential,
+                    new SchemaRegistryClientOptions
+                    {
+                        Diagnostics =
+                        {
+                            ApplicationId = "net-avro-kafka-ser-1.0"
+                        }
+                    }),
                 schemaGroup,
                 new SchemaRegistryAvroSerializerOptions()
                 {

--- a/csharp/json/samples/Worker.cs
+++ b/csharp/json/samples/Worker.cs
@@ -44,7 +44,8 @@ namespace EventHubsForKafkaSample
                 var valueSerializer = new KafkaJsonSerializer<CustomerInvoice>(
                     schemaRegistryUrl, 
                     credential,
-                    schemaGroup);
+                    schemaGroup,
+                    autoRegisterSchemas: true);
 
                 using (var producer = new ProducerBuilder<string, CustomerInvoice>(config).SetKeySerializer(Serializers.Utf8).SetValueSerializer(valueSerializer).Build())
                 {

--- a/csharp/json/src/KafkaJsonDeserializer.cs
+++ b/csharp/json/src/KafkaJsonDeserializer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Kafka.SchemaRegistry.Json
             {
                 Diagnostics =
                 {
-                    ApplicationId = "KafkaJsonSerializer/1.0"
+                    ApplicationId = "net-json-kafka-des-1.0"
                 }
             });
             this.serializer = new JsonSerializer();

--- a/csharp/json/src/KafkaJsonDeserializer.cs
+++ b/csharp/json/src/KafkaJsonDeserializer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Kafka.SchemaRegistry.Json
             {
                 Diagnostics =
                 {
-                    ApplicationId = "azsdk-net-KafkaJsonDeserializer/1.0"
+                    ApplicationId = "KafkaJsonSerializer/1.0"
                 }
             });
             this.serializer = new JsonSerializer();

--- a/csharp/json/src/KafkaJsonSerializer.cs
+++ b/csharp/json/src/KafkaJsonSerializer.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Kafka.SchemaRegistry.Json
             {
                 Diagnostics =
                 {
-                    ApplicationId = "KafkaJsonSerializer/1.0"
+                    ApplicationId = "net-json-kafka-ser-1.0"
                 }
             });
             this.autoRegisterSchemas = autoRegisterSchemas;

--- a/java/avro/src/main/java/com/microsoft/azure/schemaregistry/kafka/avro/KafkaAvroDeserializer.java
+++ b/java/avro/src/main/java/com/microsoft/azure/schemaregistry/kafka/avro/KafkaAvroDeserializer.java
@@ -5,6 +5,7 @@ package com.microsoft.azure.schemaregistry.kafka.avro;
 
 import com.azure.core.models.MessageContent;
 import com.azure.core.util.BinaryData;
+import com.azure.core.util.ClientOptions;
 import com.azure.core.util.serializer.TypeReference;
 import com.azure.data.schemaregistry.SchemaRegistryClientBuilder;
 import com.azure.data.schemaregistry.apacheavro.SchemaRegistryApacheAvroSerializer;
@@ -53,6 +54,7 @@ public class KafkaAvroDeserializer<T extends IndexedRecord> implements Deseriali
                 new SchemaRegistryClientBuilder()
                     .fullyQualifiedNamespace(this.config.getSchemaRegistryUrl())
                     .credential(this.config.getCredential())
+                    .clientOptions(new ClientOptions().setApplicationId("java-avro-kafka-des-1.0"))
                     .buildAsyncClient())
             .avroSpecificReader(this.config.getAvroSpecificReader())
             .buildSerializer();

--- a/java/avro/src/main/java/com/microsoft/azure/schemaregistry/kafka/avro/KafkaAvroSerializer.java
+++ b/java/avro/src/main/java/com/microsoft/azure/schemaregistry/kafka/avro/KafkaAvroSerializer.java
@@ -4,6 +4,7 @@
 package com.microsoft.azure.schemaregistry.kafka.avro;
 
 import com.azure.core.models.MessageContent;
+import com.azure.core.util.ClientOptions;
 import com.azure.core.util.serializer.TypeReference;
 import com.azure.data.schemaregistry.SchemaRegistryClientBuilder;
 import com.azure.data.schemaregistry.apacheavro.SchemaRegistryApacheAvroSerializer;
@@ -51,6 +52,7 @@ public class KafkaAvroSerializer<T> implements Serializer<T> {
                 .schemaRegistryClient(new SchemaRegistryClientBuilder()
                         .fullyQualifiedNamespace(config.getSchemaRegistryUrl())
                         .credential(config.getCredential())
+                        .clientOptions(new ClientOptions().setApplicationId("java-avro-kafka-ser-1.0"))
                         .buildAsyncClient())
                 .schemaGroup(config.getSchemaGroup())
                 .autoRegisterSchemas(config.getAutoRegisterSchemas())

--- a/java/json/pom.xml
+++ b/java/json/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>azure-schemaregistry-kafka-json</artifactId>
-  <version>1.0.0-beta.1</version>
+  <version>1.0.0-beta.2</version>
   <name>azure-schemaregistry-kafka-json</name>
 
   <scm>

--- a/java/json/samples/comsumer/pom.xml
+++ b/java/json/samples/comsumer/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>azure-schemaregistry-kafka-json</artifactId>
-      <version>1.0.0-beta.1</version>
+      <version>1.0.0-beta.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/java/json/samples/producer/pom.xml
+++ b/java/json/samples/producer/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>azure-schemaregistry-kafka-json</artifactId>
-      <version>1.0.0-beta.1</version>
+      <version>1.0.0-beta.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/java/json/src/main/java/com/microsoft/azure/schemaregistry/kafka/json/KafkaJsonDeserializer.java
+++ b/java/json/src/main/java/com/microsoft/azure/schemaregistry/kafka/json/KafkaJsonDeserializer.java
@@ -52,7 +52,7 @@ public class KafkaJsonDeserializer<T> implements Deserializer<T> {
         this.client = new SchemaRegistryClientBuilder()
         .fullyQualifiedNamespace(this.config.getSchemaRegistryUrl())
         .credential(this.config.getCredential())
-        .clientOptions(new ClientOptions().setApplicationId("KafkaJsonSerializer/1.0"))
+        .clientOptions(new ClientOptions().setApplicationId("java-json-kafka-des-1.0"))
         .buildClient();
     }
 

--- a/java/json/src/main/java/com/microsoft/azure/schemaregistry/kafka/json/KafkaJsonSerializer.java
+++ b/java/json/src/main/java/com/microsoft/azure/schemaregistry/kafka/json/KafkaJsonSerializer.java
@@ -56,7 +56,7 @@ public class KafkaJsonSerializer<T> implements Serializer<T> {
         this.client = new SchemaRegistryClientBuilder()
         .fullyQualifiedNamespace(config.getSchemaRegistryUrl())
         .credential(config.getCredential())
-        .clientOptions(new ClientOptions().setApplicationId("KafkaJsonSerializer/1.0"))
+        .clientOptions(new ClientOptions().setApplicationId("java-json-kafka-ser-1.0"))
         .buildClient();
     }
 


### PR DESCRIPTION
This PR adds a check in the Java and .NET serializers using schema registry for the auto-register schema configuration. Previously the code always registered new schemas upon serialization; this fix allows the user to set the auto-register behavior in the serializer configuration before running the serializers.